### PR TITLE
feat: Migrate Telegram bot to a server-agnostic Discord bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,15 @@
-# Telegram Bot Token (BotFather)
-TELEGRAM_BOT_TOKEN=your_bot_token_here
+# Discord Bot Token from Discord Developer Portal
+# 1. Go to https://discord.com/developers/applications
+# 2. Create a new application
+# 3. Go to the "Bot" tab and click "Add Bot"
+# 4. Copy the token under the bot's username
+DISCORD_BOT_TOKEN=your_bot_token_here
 
 # Price check interval (minutes)
 CHECK_INTERVAL=30
 
-# Allowed Telegram Group IDs (comma-separated)
-# To find group IDs:
-# 1. Add the bot to the group
-# 2. Send a message in the group
-# 3. Visit https://api.telegram.org/bot{BOT_TOKEN}/getUpdates
-# 4. In the JSON response, look for "chat":{"id": -1001234567890}
-# Example: ALLOWED_GROUP_IDS=-1001234567890,-1009876543210
-ALLOWED_GROUP_IDS=
-
-# Admin Chat ID for error notifications (your personal chat ID)
-# To find your chat ID:
-# 1. Send a message to your bot
-# 2. Visit https://api.telegram.org/bot{BOT_TOKEN}/getUpdates
-# 3. Look for "from":{"id": 123456789} - copy this number
-ADMIN_CHAT_ID=
+# Admin User ID for error notifications
+# To find your user ID:
+# 1. Enable Developer Mode in Discord (User Settings > Advanced)
+# 2. Right-click your username and select "Copy User ID"
+ADMIN_USER_ID=

--- a/config.py
+++ b/config.py
@@ -12,28 +12,20 @@ logger = logging.getLogger(__name__)
 # Load environment variables
 load_dotenv()
 
-# Telegram bot token
-TELEGRAM_BOT_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
+# Discord bot token
+DISCORD_BOT_TOKEN = os.getenv('DISCORD_BOT_TOKEN')
 
 # Check interval in minutes
 CHECK_INTERVAL = int(os.getenv('CHECK_INTERVAL', '30'))
 
-# Allowed Group IDs
-ALLOWED_GROUP_IDS_STR = os.getenv('ALLOWED_GROUP_IDS', '')
-ALLOWED_GROUP_IDS = [int(group_id.strip()) for group_id in ALLOWED_GROUP_IDS_STR.split(',') if group_id.strip()]
+# Admin User ID for error notifications
+ADMIN_USER_ID = os.getenv('ADMIN_USER_ID', '')
 
-# Admin Chat ID for error notifications
-ADMIN_CHAT_ID = os.getenv('ADMIN_CHAT_ID', '')
-
-if not ALLOWED_GROUP_IDS:
-    logger.warning("No ALLOWED_GROUP_IDS set in .env file. Bot will not respond to any group.")
-
-if not ADMIN_CHAT_ID:
-    logger.warning("No ADMIN_CHAT_ID set in .env file. Error notifications will not be sent.")
+if not ADMIN_USER_ID:
+    logger.warning("No ADMIN_USER_ID set in .env file. Error notifications will not be sent.")
 
 # File to store tracked product data
 DATA_FILE = 'tracked_products.json'
 
 # User agent for requests
 USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
-

--- a/data_manager.py
+++ b/data_manager.py
@@ -35,16 +35,16 @@ def save_data(data):
         logger.error(f"Error saving data to {DATA_FILE}: {e}")
         return False
 
-def add_product(chat_id, product_url, product_name, price):
+def add_product(channel_id, product_url, product_name, price):
     """Add a product to tracked products."""
     data = load_data()
     
-    # Create chat_id entry if it doesn't exist
-    if str(chat_id) not in data:
-        data[str(chat_id)] = {}
+    # Create channel_id entry if it doesn't exist
+    if str(channel_id) not in data:
+        data[str(channel_id)] = {}
     
     # Add or update the product
-    data[str(chat_id)][product_url] = {
+    data[str(channel_id)][product_url] = {
         "initial_price": price,
         "current_price": price,
         "product_name": product_name
@@ -52,45 +52,45 @@ def add_product(chat_id, product_url, product_name, price):
     
     return save_data(data)
 
-def remove_product(chat_id, product_url):
+def remove_product(channel_id, product_url):
     """Remove a product from tracked products."""
     data = load_data()
     
-    # Check if chat_id exists
-    if str(chat_id) not in data:
+    # Check if channel_id exists
+    if str(channel_id) not in data:
         return False
     
-    # Check if product_url exists in chat_id
-    if product_url not in data[str(chat_id)]:
+    # Check if product_url exists in channel_id
+    if product_url not in data[str(channel_id)]:
         return False
     
     # Remove the product
-    del data[str(chat_id)][product_url]
+    del data[str(channel_id)][product_url]
     
-    # Remove the chat_id if there are no products left
-    if not data[str(chat_id)]:
-        del data[str(chat_id)]
+    # Remove the channel_id if there are no products left
+    if not data[str(channel_id)]:
+        del data[str(channel_id)]
     
     return save_data(data)
 
-def get_all_products(chat_id=None):
-    """Get all tracked products, optionally filtered by chat_id."""
+def get_all_products(channel_id=None):
+    """Get all tracked products, optionally filtered by channel_id."""
     data = load_data()
     
-    if chat_id is not None:
-        return data.get(str(chat_id), {})
+    if channel_id is not None:
+        return data.get(str(channel_id), {})
     
     return data
 
-def update_product_price(chat_id, product_url, new_price):
+def update_product_price(channel_id, product_url, new_price):
     """Update current price of a product."""
     data = load_data()
     
-    # Check if chat_id and product_url exist
-    if str(chat_id) not in data or product_url not in data[str(chat_id)]:
+    # Check if channel_id and product_url exist
+    if str(channel_id) not in data or product_url not in data[str(channel_id)]:
         return False
     
     # Update the current price
-    data[str(chat_id)][product_url]["current_price"] = new_price
+    data[str(channel_id)][product_url]["current_price"] = new_price
     
     return save_data(data)

--- a/data_manager.py
+++ b/data_manager.py
@@ -35,7 +35,7 @@ def save_data(data):
         logger.error(f"Error saving data to {DATA_FILE}: {e}")
         return False
 
-def add_product(channel_id, product_url, product_name, price):
+def add_product(channel_id, product_url, product_name, price, image_url):
     """Add a product to tracked products."""
     data = load_data()
     
@@ -47,7 +47,8 @@ def add_product(channel_id, product_url, product_name, price):
     data[str(channel_id)][product_url] = {
         "initial_price": price,
         "current_price": price,
-        "product_name": product_name
+        "product_name": product_name,
+        "image_url": image_url
     }
     
     return save_data(data)

--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ async def on_ready():
     """Event triggered when the bot is ready."""
     logger.info(f'Logged in as {bot.user.name}')
     logger.info("Bot is ready and running!")
+    await bot.tree.sync()
     # Start the scheduler
     schedule.every(CHECK_INTERVAL).minutes.do(lambda: asyncio.run_coroutine_threadsafe(check_prices(), bot.loop))
     # Run scheduler in a separate thread
@@ -63,7 +64,7 @@ async def run_scheduler():
         schedule.run_pending()
         await asyncio.sleep(1)
 
-@bot.command(name='start', aliases=['yardim'])
+@bot.hybrid_command(name='start', aliases=['yardim'])
 async def start(ctx):
     """Send a welcome message."""
     embed = discord.Embed(
@@ -71,21 +72,17 @@ async def start(ctx):
         description='Komutlar:\n'
                     '`/ekle [Trendyol linki]` - Fiyat takibi için yeni bir ürün ekler\n'
                     '`/sil [Trendyol linki]` - Takipten bir ürün çıkarır\n'
-                    '`/listele` - Takip edilen tüm ürünleri listeler\n'
+                    '`/takiptekiler` - Takip edilen ürünleri listeler\n'
+                    '`/bilgi [Trendyol linki]` - Ürün hakkında bilgi verir (takibe almaz)\n'
                     '`/yenile` - Tüm ürünlerin fiyatlarını manuel olarak kontrol eder\n\n'
                     'Ayrıca, direkt olarak Trendyol.com veya ty.gl linki göndererek de ürün ekleyebilirsiniz.',
         color=0x00ff00
     )
     await ctx.send(embed=embed)
 
-@bot.command(name='ekle')
-async def add_product_handler(ctx, *, url: str = None):
+@bot.hybrid_command(name='ekle')
+async def add_product_handler(ctx, *, url: str):
     """Add a product to track."""
-    if url is None:
-        await ctx.send('Lütfen geçerli bir Trendyol linki ekleyin.\n'
-                       'Örnek: /ekle https://www.trendyol.com/...')
-        return
-
     url = extract_url(url)
     if not url or not is_valid_trendyol_url(url):
         await ctx.send('Geçerli bir Trendyol linki bulunamadı.')
@@ -117,14 +114,9 @@ async def add_product_handler(ctx, *, url: str = None):
     else:
         await message.edit(content='Ürün eklenirken bir hata oluştu. Lütfen daha sonra tekrar deneyin.')
 
-@bot.command(name='sil')
-async def remove_product_handler(ctx, *, url: str = None):
+@bot.hybrid_command(name='sil')
+async def remove_product_handler(ctx, *, url: str):
     """Remove a product from tracking."""
-    if url is None:
-        await ctx.send('Lütfen silmek istediğiniz ürünün Trendyol linkini ekleyin.\n'
-                       'Örnek: /sil https://www.trendyol.com/...')
-        return
-
     url = extract_url(url)
     if not url:
         await ctx.send('Geçerli bir Trendyol linki bulunamadı.')
@@ -137,44 +129,116 @@ async def remove_product_handler(ctx, *, url: str = None):
     else:
         await ctx.send('Ürün bulunamadı veya zaten takip edilmiyor.')
 
-@bot.command(name='listele')
-async def list_products(ctx):
-    """List all tracked products."""
-    products = get_all_products(ctx.channel.id)
-    
-    if not products:
-        await ctx.send('Henüz takip edilen ürün bulunmamaktadır.')
+@bot.hybrid_command(name='takiptekiler', description="Takip edilen ürünleri listeler. Admin tüm ürünleri görür.")
+async def takiptekiler(ctx):
+    """List all tracked products. Admins can see all products from all channels."""
+    # Check if the invoker is the admin
+    is_admin = str(ctx.author.id) == ADMIN_USER_ID
+
+    if is_admin:
+        # Admin view: show all products from all channels
+        all_data = get_all_products()
+        if not all_data:
+            await ctx.send('Hiçbir kanalda takip edilen ürün bulunmamaktadır.', ephemeral=True)
+            return
+
+        embed = discord.Embed(title='Tüm Kanallarda Takip Edilen Ürünler (Admin)', color=0x0000ff)
+        total_products = 0
+        
+        for channel_id, products in all_data.items():
+            try:
+                channel = await bot.fetch_channel(int(channel_id))
+                channel_name = f"#{channel.name} ({channel.guild.name})"
+            except (discord.NotFound, discord.Forbidden):
+                channel_name = f"Bilinmeyen Kanal ({channel_id})"
+
+            product_list_str = ""
+            for i, (url, product_info) in enumerate(products.items()):
+                total_products += 1
+                product_name = product_info.get('product_name', 'İsimsiz Ürün')
+                current_price = product_info.get('current_price', 0)
+
+                if current_price == 0:
+                    product_list_str += f"• **{product_name}** - Tükendi ([Link]({url}))\n"
+                else:
+                    product_list_str += f"• **{product_name}** - {current_price:.2f} TL ([Link]({url}))\n"
+
+            if product_list_str:
+                embed.add_field(name=channel_name, value=product_list_str, inline=False)
+
+        if not embed.fields:
+             await ctx.send('Hiçbir kanalda takip edilen ürün bulunmamaktadır.', ephemeral=True)
+             return
+
+        embed.set_footer(text=f"Toplam {len(all_data)} kanal ve {total_products} ürün izleniyor.")
+        await ctx.send(embed=embed, ephemeral=True)
+
+    else:
+        # Regular user view: show products for the current channel
+        products = get_all_products(ctx.channel.id)
+
+        if not products:
+            await ctx.send('Bu kanalda takip edilen ürün bulunmamaktadır.')
+            return
+
+        embed = discord.Embed(title='Takip Edilen Ürünler', color=0x00ff00)
+
+        for url, product_info in products.items():
+            product_name = product_info.get('product_name', 'İsimsiz Ürün')
+            current_price = product_info.get('current_price', 0)
+
+            if current_price == 0:
+                embed.add_field(name=product_name, value=f'**Tükendi**\n[Link]({url})', inline=False)
+                continue
+
+            initial_price = product_info.get('initial_price', 0)
+            price_diff = current_price - initial_price
+
+            if price_diff > 0:
+                price_trend = f'📈 +{price_diff:.2f} TL'
+            elif price_diff < 0:
+                price_trend = f'📉 {price_diff:.2f} TL'
+            else:
+                price_trend = '➡️ Değişim yok'
+
+            embed.add_field(
+                name=product_name,
+                value=f'**Güncel Fiyat:** {current_price:.2f} TL {price_trend}\n[Link]({url})',
+                inline=False
+            )
+
+        await ctx.send(embed=embed)
+
+@bot.hybrid_command(name='bilgi', description="Verilen linkteki ürün hakkında bilgi verir.")
+async def bilgi(ctx, *, url: str):
+    """Provides information about a product from a given URL without tracking it."""
+    url = extract_url(url)
+    if not url or not is_valid_trendyol_url(url):
+        await ctx.send('Lütfen geçerli bir Trendyol linki girin.')
         return
 
-    embed = discord.Embed(title='Takip Edilen Ürünler', color=0x00ff00)
-    
-    for url, product_info in products.items():
-        product_name = product_info.get('product_name', 'İsimsiz Ürün')
-        current_price = product_info.get('current_price', 0)
-        
-        if current_price == 0:
-            embed.add_field(name=product_name, value=f'**Tükendi**\n[Link]({url})', inline=False)
-            continue
-        
-        initial_price = product_info.get('initial_price', 0)
-        price_diff = current_price - initial_price
+    message = await ctx.send('Ürün bilgileri alınıyor...')
 
-        if price_diff > 0:
-            price_trend = f'📈 +{price_diff:.2f} TL'
-        elif price_diff < 0:
-            price_trend = f'📉 {price_diff:.2f} TL'
-        else:
-            price_trend = '➡️ Değişim yok'
+    product_name, price, error = scrape_product_info(url)
 
-        embed.add_field(
-            name=product_name,
-            value=f'**Güncel Fiyat:** {current_price:.2f} TL {price_trend}\n[Link]({url})',
-            inline=False
-        )
+    if error:
+        await message.edit(content=f'Hata: {error}')
+        return
 
-    await ctx.send(embed=embed)
+    if not price:
+        await message.edit(content='Ürün fiyatı alınamadı. Lütfen linki kontrol edin.')
+        return
 
-@bot.command(name='yenile')
+    embed = discord.Embed(
+        title='Ürün Bilgisi',
+        description=f"**Ürün:** {product_name}\n**Güncel Fiyat:** {price:.2f} TL",
+        color=0x00bfff  # Deep Sky Blue
+    )
+    embed.add_field(name="Link", value=url)
+
+    await message.edit(content=None, embed=embed)
+
+@bot.hybrid_command(name='yenile')
 async def refresh_prices_handler(ctx):
     """Manual refresh command to check all tracked products immediately."""
     products = get_all_products(ctx.channel.id)

--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ async def add_product_handler(ctx, *, url: str):
 
     message = await ctx.send('Ürün bilgileri alınıyor...')
     
-    product_name, price, error = scrape_product_info(url)
+    product_name, price, image_url, error = scrape_product_info(url)
     
     if error:
         await message.edit(content=f'Hata: {error}')
@@ -100,7 +100,7 @@ async def add_product_handler(ctx, *, url: str):
         await message.edit(content='Ürün fiyatı alınamadı. Lütfen linki kontrol edin.')
         return
     
-    success = add_product(ctx.channel.id, url, product_name, price)
+    success = add_product(ctx.channel.id, url, product_name, price, image_url)
     
     if success:
         embed = discord.Embed(
@@ -110,6 +110,8 @@ async def add_product_handler(ctx, *, url: str):
                         f'Fiyat değiştiğinde size bildirim göndereceğim.',
             color=0x00ff00
         )
+        if image_url:
+            embed.set_thumbnail(url=image_url)
         await message.edit(content=None, embed=embed)
     else:
         await message.edit(content='Ürün eklenirken bir hata oluştu. Lütfen daha sonra tekrar deneyin.')
@@ -132,19 +134,16 @@ async def remove_product_handler(ctx, *, url: str):
 @bot.hybrid_command(name='takiptekiler', description="Takip edilen ürünleri listeler. Admin tüm ürünleri görür.")
 async def takiptekiler(ctx):
     """List all tracked products. Admins can see all products from all channels."""
-    # Check if the invoker is the admin
     is_admin = str(ctx.author.id) == ADMIN_USER_ID
 
     if is_admin:
-        # Admin view: show all products from all channels
         all_data = get_all_products()
         if not all_data:
             await ctx.send('Hiçbir kanalda takip edilen ürün bulunmamaktadır.', ephemeral=True)
             return
 
-        embed = discord.Embed(title='Tüm Kanallarda Takip Edilen Ürünler (Admin)', color=0x0000ff)
-        total_products = 0
-        
+        await ctx.send("Tüm kanallardaki ürünler listeleniyor...", ephemeral=True)
+
         for channel_id, products in all_data.items():
             try:
                 channel = await bot.fetch_channel(int(channel_id))
@@ -152,62 +151,47 @@ async def takiptekiler(ctx):
             except (discord.NotFound, discord.Forbidden):
                 channel_name = f"Bilinmeyen Kanal ({channel_id})"
 
-            product_list_str = ""
-            for i, (url, product_info) in enumerate(products.items()):
-                total_products += 1
-                product_name = product_info.get('product_name', 'İsimsiz Ürün')
+            for url, product_info in products.items():
+                embed = discord.Embed(title=product_info.get('product_name', 'İsimsiz Ürün'), color=0x0000ff)
+                embed.add_field(name="Kanal", value=channel_name, inline=False)
                 current_price = product_info.get('current_price', 0)
-
                 if current_price == 0:
-                    product_list_str += f"• **{product_name}** - Tükendi ([Link]({url}))\n"
+                    embed.add_field(name="Durum", value="Tükendi", inline=False)
                 else:
-                    product_list_str += f"• **{product_name}** - {current_price:.2f} TL ([Link]({url}))\n"
-
-            if product_list_str:
-                embed.add_field(name=channel_name, value=product_list_str, inline=False)
-
-        if not embed.fields:
-             await ctx.send('Hiçbir kanalda takip edilen ürün bulunmamaktadır.', ephemeral=True)
-             return
-
-        embed.set_footer(text=f"Toplam {len(all_data)} kanal ve {total_products} ürün izleniyor.")
-        await ctx.send(embed=embed, ephemeral=True)
-
+                    embed.add_field(name="Fiyat", value=f"{current_price:.2f} TL", inline=False)
+                if product_info.get('image_url'):
+                    embed.set_thumbnail(url=product_info.get('image_url'))
+                embed.add_field(name="Link", value=url, inline=False)
+                await ctx.send(embed=embed, ephemeral=True)
     else:
-        # Regular user view: show products for the current channel
         products = get_all_products(ctx.channel.id)
-
         if not products:
             await ctx.send('Bu kanalda takip edilen ürün bulunmamaktadır.')
             return
 
-        embed = discord.Embed(title='Takip Edilen Ürünler', color=0x00ff00)
-
+        await ctx.send(f"Bu kanalda takip edilen {len(products)} ürün listeleniyor...")
         for url, product_info in products.items():
             product_name = product_info.get('product_name', 'İsimsiz Ürün')
             current_price = product_info.get('current_price', 0)
 
+            embed = discord.Embed(title=product_name, color=0x00ff00)
             if current_price == 0:
-                embed.add_field(name=product_name, value=f'**Tükendi**\n[Link]({url})', inline=False)
-                continue
-
-            initial_price = product_info.get('initial_price', 0)
-            price_diff = current_price - initial_price
-
-            if price_diff > 0:
-                price_trend = f'📈 +{price_diff:.2f} TL'
-            elif price_diff < 0:
-                price_trend = f'📉 {price_diff:.2f} TL'
+                embed.add_field(name="Durum", value="Tükendi", inline=False)
             else:
-                price_trend = '➡️ Değişim yok'
+                initial_price = product_info.get('initial_price', 0)
+                price_diff = current_price - initial_price
+                if price_diff > 0:
+                    price_trend = f'📈 +{price_diff:.2f} TL'
+                elif price_diff < 0:
+                    price_trend = f'📉 {price_diff:.2f} TL'
+                else:
+                    price_trend = '➡️ Değişim yok'
+                embed.add_field(name="Fiyat", value=f'{current_price:.2f} TL {price_trend}', inline=False)
 
-            embed.add_field(
-                name=product_name,
-                value=f'**Güncel Fiyat:** {current_price:.2f} TL {price_trend}\n[Link]({url})',
-                inline=False
-            )
-
-        await ctx.send(embed=embed)
+            if product_info.get('image_url'):
+                embed.set_thumbnail(url=product_info.get('image_url'))
+            embed.add_field(name="Link", value=url, inline=False)
+            await ctx.send(embed=embed)
 
 @bot.hybrid_command(name='bilgi', description="Verilen linkteki ürün hakkında bilgi verir.")
 async def bilgi(ctx, *, url: str):
@@ -219,7 +203,7 @@ async def bilgi(ctx, *, url: str):
 
     message = await ctx.send('Ürün bilgileri alınıyor...')
 
-    product_name, price, error = scrape_product_info(url)
+    product_name, price, image_url, error = scrape_product_info(url)
 
     if error:
         await message.edit(content=f'Hata: {error}')
@@ -232,8 +216,10 @@ async def bilgi(ctx, *, url: str):
     embed = discord.Embed(
         title='Ürün Bilgisi',
         description=f"**Ürün:** {product_name}\n**Güncel Fiyat:** {price:.2f} TL",
-        color=0x00bfff  # Deep Sky Blue
+        color=0x00bfff
     )
+    if image_url:
+        embed.set_thumbnail(url=image_url)
     embed.add_field(name="Link", value=url)
 
     await message.edit(content=None, embed=embed)
@@ -258,7 +244,7 @@ async def refresh_prices_handler(ctx):
             product_name = product_info['product_name']
             current_price = product_info['current_price']
 
-            _, new_price, error = scrape_product_info(url)
+            _, new_price, _, error = scrape_product_info(url)
 
             if error:
                 error_count += 1
@@ -286,6 +272,8 @@ async def refresh_prices_handler(ctx):
                                 f'[Ürüne Git]({url})',
                     color=0xff0000 if price_diff > 0 else 0x00ff00
                 )
+                if product_info.get('image_url'):
+                    notification_embed.set_thumbnail(url=product_info.get('image_url'))
                 await ctx.send(embed=notification_embed)
         
         except Exception as e:
@@ -326,7 +314,7 @@ async def check_prices():
                 
                 logger.info(f"Checking price for {product_name} at {url}")
                 
-                _, new_price, error = scrape_product_info(url)
+                _, new_price, _, error = scrape_product_info(url)
                 
                 if error:
                     logger.error(f"Error checking {url}: {error}")
@@ -354,6 +342,9 @@ async def check_prices():
                         color=0xff0000 if price_diff > 0 else 0x00ff00
                     )
                     
+                    if product_info.get('image_url'):
+                        notification_embed.set_thumbnail(url=product_info.get('image_url'))
+
                     try:
                         channel = await bot.fetch_channel(int(channel_id))
                         await channel.send(embed=notification_embed)
@@ -396,7 +387,7 @@ async def on_message(message):
 
         msg = await message.channel.send('Ürün bilgileri alınıyor...')
 
-        product_name, price, error = scrape_product_info(url)
+        product_name, price, image_url, error = scrape_product_info(url)
 
         if error:
             await msg.edit(content=f'Hata: {error}')
@@ -406,7 +397,7 @@ async def on_message(message):
             await msg.edit(content='Ürün fiyatı alınamadı. Lütfen linki kontrol edin.')
             return
 
-        success = add_product(message.channel.id, url, product_name, price)
+        success = add_product(message.channel.id, url, product_name, price, image_url)
 
         if success:
             embed = discord.Embed(
@@ -416,6 +407,8 @@ async def on_message(message):
                             f'Fiyat değiştiğinde size bildirim göndereceğim.',
                 color=0x00ff00
             )
+            if image_url:
+                embed.set_thumbnail(url=image_url)
             await msg.edit(content=None, embed=embed)
         else:
             await msg.edit(content='Ürün eklenirken bir hata oluştu. Lütfen daha sonra tekrar deneyin.')

--- a/main.py
+++ b/main.py
@@ -1,15 +1,14 @@
 import logging
 import re
-import time
-import threading
+import asyncio
 import schedule
 import traceback
 from datetime import datetime
-from telegram import Update, ParseMode
-from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, CallbackContext
+import discord
+from discord.ext import commands
 from scraper import scrape_product_info, is_valid_trendyol_url
 from data_manager import add_product, remove_product, get_all_products, update_product_price
-from config import TELEGRAM_BOT_TOKEN, CHECK_INTERVAL, ALLOWED_GROUP_IDS, ADMIN_CHAT_ID
+from config import DISCORD_BOT_TOKEN, CHECK_INTERVAL, ADMIN_USER_ID
 
 # Configure logging
 logging.basicConfig(
@@ -18,31 +17,14 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Global variable to store bot instance
-_bot_instance = None
+# Define intents
+intents = discord.Intents.default()
+intents.messages = True
+intents.message_content = True
+intents.guilds = True
 
-def is_allowed_chat(chat_id):
-    """Check if the chat_id is in the allowed list."""
-    return chat_id in ALLOWED_GROUP_IDS
-
-def start(update: Update, context: CallbackContext):
-    """Send a message when the command /start is issued."""
-    chat_id = update.effective_chat.id
-    
-    # Check if the chat is allowed
-    if not is_allowed_chat(chat_id):
-        logger.info(f"Unauthorized start command from chat_id: {chat_id}")
-        return
-        
-    update.message.reply_text(
-        'Merhaba! Trendyol Fiyat Takip Botuna hoş geldiniz.\n\n'
-        'Komutlar:\n'
-        '/ekle [Trendyol linki] - Fiyat takibi için yeni bir ürün ekler\n'
-        '/sil [Trendyol linki] - Takipten bir ürün çıkarır\n'
-        '/listele - Takip edilen tüm ürünleri listeler\n'
-        '/yenile - Tüm ürünlerin fiyatlarını manuel olarak kontrol eder\n\n'
-        'Ayrıca, direkt olarak Trendyol.com veya ty.gl linki göndererek de ürün ekleyebilirsiniz.'
-    )
+# Create bot instance
+bot = commands.Bot(command_prefix='/', intents=intents)
 
 def extract_url(text):
     """Extract URL from text."""
@@ -50,213 +32,220 @@ def extract_url(text):
     match = re.search(url_pattern, text)
     return match.group(0) if match else None
 
-def add_product_handler(update: Update, context: CallbackContext):
+async def send_admin_notification(message):
+    """Send notification to admin user."""
+    if not ADMIN_USER_ID:
+        return False
+
+    try:
+        admin = await bot.fetch_user(int(ADMIN_USER_ID))
+        if admin:
+            await admin.send(embed=discord.Embed.from_dict({"title": "Admin Notification", "description": message, "color": 0xff0000}))
+            return True
+    except Exception as e:
+        logger.error(f"Failed to send admin notification: {e}")
+        return False
+
+@bot.event
+async def on_ready():
+    """Event triggered when the bot is ready."""
+    logger.info(f'Logged in as {bot.user.name}')
+    logger.info("Bot is ready and running!")
+    # Start the scheduler
+    schedule.every(CHECK_INTERVAL).minutes.do(lambda: asyncio.run_coroutine_threadsafe(check_prices(), bot.loop))
+    # Run scheduler in a separate thread
+    loop = asyncio.get_event_loop()
+    loop.create_task(run_scheduler())
+
+async def run_scheduler():
+    """Run the scheduler."""
+    while True:
+        schedule.run_pending()
+        await asyncio.sleep(1)
+
+@bot.command(name='start')
+async def start(ctx):
+    """Send a welcome message."""
+    embed = discord.Embed(
+        title='Merhaba! Trendyol Fiyat Takip Botuna hoş geldiniz.',
+        description='Komutlar:\n'
+                    '`/ekle [Trendyol linki]` - Fiyat takibi için yeni bir ürün ekler\n'
+                    '`/sil [Trendyol linki]` - Takipten bir ürün çıkarır\n'
+                    '`/listele` - Takip edilen tüm ürünleri listeler\n'
+                    '`/yenile` - Tüm ürünlerin fiyatlarını manuel olarak kontrol eder\n\n'
+                    'Ayrıca, direkt olarak Trendyol.com veya ty.gl linki göndererek de ürün ekleyebilirsiniz.',
+        color=0x00ff00
+    )
+    await ctx.send(embed=embed)
+
+@bot.command(name='ekle')
+async def add_product_handler(ctx, *, url: str = None):
     """Add a product to track."""
-    chat_id = update.effective_chat.id
-    
-    # Check if the chat is allowed
-    if not is_allowed_chat(chat_id):
-        logger.info(f"Unauthorized add_product command from chat_id: {chat_id}")
+    if url is None:
+        await ctx.send('Lütfen geçerli bir Trendyol linki ekleyin.\n'
+                       'Örnek: /ekle https://www.trendyol.com/...')
         return
-    
-    # Extract URL from command or message text
-    if context.args:
-        url = extract_url(' '.join(context.args))
-    else:
-        update.message.reply_text('Lütfen geçerli bir Trendyol linki ekleyin.\n'
-                                'Örnek: /ekle https://www.trendyol.com/...')
-        return
-    
+
+    url = extract_url(url)
     if not url or not is_valid_trendyol_url(url):
-        update.message.reply_text('Geçerli bir Trendyol linki bulunamadı.')
+        await ctx.send('Geçerli bir Trendyol linki bulunamadı.')
         return
+
+    message = await ctx.send('Ürün bilgileri alınıyor...')
     
-    # Send initial message
-    message = update.message.reply_text('Ürün bilgileri alınıyor...')
-    
-    # Fetch product info
     product_name, price, error = scrape_product_info(url)
     
-    if error == "Tükendi":
-        # Handle sold out product
-        success = add_product(chat_id, url, product_name, price)  # price is 0 for sold out products
-        
-        if success:
-            message.edit_text(
-                f'Ürün başarıyla eklendi!\n\n'
-                f'Ürün: {product_name}\n'
-                f'Durum: Tükendi\n\n'
-                f'Ürün tekrar stokta olduğunda size bildirim göndereceğim.'
-            )
-        else:
-            message.edit_text('Ürün eklenirken bir hata oluştu. Lütfen daha sonra tekrar deneyin.')
-        return
-    elif error:
-        message.edit_text(f'Hata: {error}')
+    if error:
+        await message.edit(content=f'Hata: {error}')
         return
     
     if not price:
-        message.edit_text('Ürün fiyatı alınamadı. Lütfen linki kontrol edin.')
+        await message.edit(content='Ürün fiyatı alınamadı. Lütfen linki kontrol edin.')
         return
     
-    # Add the product to tracking
-    success = add_product(chat_id, url, product_name, price)
+    success = add_product(ctx.channel.id, url, product_name, price)
     
     if success:
-        message.edit_text(
-            f'Ürün başarıyla eklendi!\n\n'
-            f'Ürün: {product_name}\n'
-            f'Güncel Fiyat: {price:.2f} TL\n\n'
-            f'Fiyat değiştiğinde size bildirim göndereceğim.'
+        embed = discord.Embed(
+            title='Ürün Başarıyla Eklendi!',
+            description=f'**Ürün:** {product_name}\n'
+                        f'**Güncel Fiyat:** {price:.2f} TL\n\n'
+                        f'Fiyat değiştiğinde size bildirim göndereceğim.',
+            color=0x00ff00
         )
+        await message.edit(content=None, embed=embed)
     else:
-        message.edit_text('Ürün eklenirken bir hata oluştu. Lütfen daha sonra tekrar deneyin.')
+        await message.edit(content='Ürün eklenirken bir hata oluştu. Lütfen daha sonra tekrar deneyin.')
 
-def url_handler(update: Update, context: CallbackContext):
-    """Handle messages containing Trendyol URLs."""
-    chat_id = update.effective_chat.id
-    
-    # Check if the chat is allowed
-    if not is_allowed_chat(chat_id):
-        logger.info(f"Unauthorized URL message from chat_id: {chat_id}")
-        return
-    
-    # Extract URL from message text
-    url = extract_url(update.message.text)
-    
-    if not url or not is_valid_trendyol_url(url):
-        return  # Ignore non-Trendyol URLs
-    
-    # Send initial message
-    message = update.message.reply_text('Ürün bilgileri alınıyor...')
-    
-    # Fetch product info
-    product_name, price, error = scrape_product_info(url)
-    
-    if error == "Tükendi":
-        # Handle sold out product
-        success = add_product(chat_id, url, product_name, price)  # price is 0 for sold out products
-        
-        if success:
-            message.edit_text(
-                f'Ürün başarıyla eklendi!\n\n'
-                f'Ürün: {product_name}\n'
-                f'Durum: Tükendi\n\n'
-                f'Ürün tekrar stokta olduğunda size bildirim göndereceğim.'
-            )
-        else:
-            message.edit_text('Ürün eklenirken bir hata oluştu. Lütfen daha sonra tekrar deneyin.')
-        return
-    elif error:
-        message.edit_text(f'Hata: {error}')
-        return
-    
-    if not price:
-        message.edit_text('Ürün fiyatı alınamadı. Lütfen linki kontrol edin.')
-        return
-    
-    # Add the product to tracking
-    success = add_product(chat_id, url, product_name, price)
-    
-    if success:
-        message.edit_text(
-            f'Ürün başarıyla eklendi!\n\n'
-            f'Ürün: {product_name}\n'
-            f'Güncel Fiyat: {price:.2f} TL\n\n'
-            f'Fiyat değiştiğinde size bildirim göndereceğim.'
-        )
-    else:
-        message.edit_text('Ürün eklenirken bir hata oluştu. Lütfen daha sonra tekrar deneyin.')
-
-def remove_product_handler(update: Update, context: CallbackContext):
+@bot.command(name='sil')
+async def remove_product_handler(ctx, *, url: str = None):
     """Remove a product from tracking."""
-    chat_id = update.effective_chat.id
-    
-    # Check if the chat is allowed
-    if not is_allowed_chat(chat_id):
-        logger.info(f"Unauthorized remove_product command from chat_id: {chat_id}")
+    if url is None:
+        await ctx.send('Lütfen silmek istediğiniz ürünün Trendyol linkini ekleyin.\n'
+                       'Örnek: /sil https://www.trendyol.com/...')
         return
-    
-    # Extract URL from command
-    if context.args:
-        url = extract_url(' '.join(context.args))
-    else:
-        update.message.reply_text('Lütfen silmek istediğiniz ürünün Trendyol linkini ekleyin.\n'
-                                'Örnek: /sil https://www.trendyol.com/...')
-        return
-    
+
+    url = extract_url(url)
     if not url:
-        update.message.reply_text('Geçerli bir Trendyol linki bulunamadı.')
+        await ctx.send('Geçerli bir Trendyol linki bulunamadı.')
         return
-    
-    # Remove the product from tracking
-    success = remove_product(chat_id, url)
+
+    success = remove_product(ctx.channel.id, url)
     
     if success:
-        update.message.reply_text('Ürün takipten çıkarıldı.')
+        await ctx.send('Ürün takipten çıkarıldı.')
     else:
-        update.message.reply_text('Ürün bulunamadı veya zaten takip edilmiyor.')
+        await ctx.send('Ürün bulunamadı veya zaten takip edilmiyor.')
 
-def list_products(update: Update, context: CallbackContext):
+@bot.command(name='listele')
+async def list_products(ctx):
     """List all tracked products."""
-    chat_id = update.effective_chat.id
-    
-    # Check if the chat is allowed
-    if not is_allowed_chat(chat_id):
-        logger.info(f"Unauthorized list_products command from chat_id: {chat_id}")
-        return
-    
-    # Get all products for this chat
-    products = get_all_products(chat_id)
+    products = get_all_products(ctx.channel.id)
     
     if not products:
-        update.message.reply_text('Henüz takip edilen ürün bulunmamaktadır.')
+        await ctx.send('Henüz takip edilen ürün bulunmamaktadır.')
         return
-    
-    # Prepare the message text
-    message = 'Takip Edilen Ürünler:\n\n'
+
+    embed = discord.Embed(title='Takip Edilen Ürünler', color=0x00ff00)
     
     for url, product_info in products.items():
         product_name = product_info.get('product_name', 'İsimsiz Ürün')
         current_price = product_info.get('current_price', 0)
-        initial_price = product_info.get('initial_price', 0)
         
-        # Check if product is sold out (price is 0)
         if current_price == 0:
-            message += (
-                f'🔹 <b>{product_name}</b>\n'
-                f'   <b>Tükendi</b>\n'
-                f'   <a href="{url}">Link</a>\n\n'
-            )
+            embed.add_field(name=product_name, value=f'**Tükendi**\n[Link]({url})', inline=False)
             continue
         
+        initial_price = product_info.get('initial_price', 0)
         price_diff = current_price - initial_price
+
         if price_diff > 0:
             price_trend = f'📈 +{price_diff:.2f} TL'
         elif price_diff < 0:
             price_trend = f'📉 {price_diff:.2f} TL'
         else:
             price_trend = '➡️ Değişim yok'
-        
-        message += (
-            f'🔹 <b>{product_name}</b>\n'
-            f'   Güncel Fiyat: <b>{current_price:.2f} TL</b> {price_trend}\n'
-            f'   <a href="{url}">Link</a>\n\n'
+
+        embed.add_field(
+            name=product_name,
+            value=f'**Güncel Fiyat:** {current_price:.2f} TL {price_trend}\n[Link]({url})',
+            inline=False
         )
-    
-    update.message.reply_text(message, parse_mode=ParseMode.HTML, disable_web_page_preview=True)
 
-# Global variable to store bot instance
-_bot_instance = None
+    await ctx.send(embed=embed)
 
-def check_prices():
-    """Check prices for all tracked products and notify if there's a change."""
-    global _bot_instance
+@bot.command(name='yenile')
+async def refresh_prices_handler(ctx):
+    """Manual refresh command to check all tracked products immediately."""
+    products = get_all_products(ctx.channel.id)
     
-    if not _bot_instance:
-        logger.error("Bot instance not available for price checking")
+    if not products:
+        await ctx.send('Henüz takip edilen ürün bulunmamaktadır.')
         return
+
+    message = await ctx.send(f'🔄 Fiyatlar kontrol ediliyor... ({len(products)} ürün)')
+
+    checked_count = 0
+    changed_count = 0
+    error_count = 0
+
+    for url, product_info in products.items():
+        try:
+            product_name = product_info['product_name']
+            current_price = product_info['current_price']
+
+            _, new_price, error = scrape_product_info(url)
+
+            if error:
+                error_count += 1
+                continue
+
+            if new_price is None:
+                error_count += 1
+                continue
+
+            checked_count += 1
+
+            if abs(new_price - current_price) > 0.01:
+                changed_count += 1
+                update_product_price(ctx.channel.id, url, new_price)
+
+                price_diff = new_price - current_price
+                trend_emoji = "📈 Fiyat Yükseldi" if price_diff > 0 else "📉 Fiyat Düştü"
+
+                notification_embed = discord.Embed(
+                    title=f'{trend_emoji}!',
+                    description=f'**{product_name}**\n'
+                                f'**Eski Fiyat:** {current_price:.2f} TL\n'
+                                f'**Yeni Fiyat:** {new_price:.2f} TL\n'
+                                f'**Fark:** {price_diff:+.2f} TL (%{(price_diff/current_price*100):+.1f})\n\n'
+                                f'[Ürüne Git]({url})',
+                    color=0xff0000 if price_diff > 0 else 0x00ff00
+                )
+                await ctx.send(embed=notification_embed)
         
+        except Exception as e:
+            error_count += 1
+            logger.error(f"Error checking price for {url}: {e}")
+
+    status_emoji = "⚠️" if error_count > 0 else "✅"
+    status_text = f"tamamlandı (bazı hatalarla)" if error_count > 0 else "tamamlandı"
+
+    final_embed = discord.Embed(
+        title=f'{status_emoji} Fiyat kontrolü {status_text}',
+        description=f'📊 **Özet:**\n'
+                    f'• Toplam ürün: {len(products)}\n'
+                    f'• Kontrol edilen: {checked_count}\n'
+                    f'• Fiyat değişen: {changed_count}\n'
+                    f'• Hata: {error_count}\n\n'
+                    f'💡 Otomatik kontrol {CHECK_INTERVAL} dakikada bir yapılmaktadır.',
+        color=0xffa500 if error_count > 0 else 0x00ff00
+    )
+
+    await message.edit(content=None, embed=final_embed)
+
+async def check_prices():
+    """Check prices for all tracked products and notify if there's a change."""
     data = get_all_products()
     
     if not data:
@@ -265,7 +254,7 @@ def check_prices():
     
     error_count = 0
     
-    for chat_id, products in data.items():
+    for channel_id, products in data.items():
         for url, product_info in list(products.items()):
             try:
                 product_name = product_info['product_name']
@@ -273,68 +262,11 @@ def check_prices():
                 
                 logger.info(f"Checking price for {product_name} at {url}")
                 
-                # Fetch new product info
                 _, new_price, error = scrape_product_info(url)
-                
-                # Handle sold-out products specially
-                if error == "Tükendi":
-                    # Product is sold out
-                    if current_price != 0:  # Only update if not already marked as sold out
-                        update_product_price(chat_id, url, 0)
-                        
-                        # Send sold-out notification
-                        notification_text = (
-                            f'🚫 <b>Ürün Tükendi!</b>\n\n'
-                            f'<b>{product_name}</b>\n'
-                            f'Eski Fiyat: <b>{current_price:.2f} TL</b>\n'
-                            f'Durum: <b>Stoklar Tükendi</b>\n\n'
-                            f'Ürün tekrar stokta olduğunda bildirim göndereceğim.\n\n'
-                            f'<a href="{url}">Ürüne Git</a>'
-                        )
-                        
-                        try:
-                            _bot_instance.send_message(
-                                chat_id=int(chat_id),
-                                text=notification_text,
-                                parse_mode=ParseMode.HTML,
-                                disable_web_page_preview=True
-                            )
-                            logger.info(f"Sold-out notification sent to {chat_id}")
-                        except Exception as send_error:
-                            logger.error(f"Failed to send sold-out notification to {chat_id}: {send_error}")
-                            error_count += 1
-                    else:
-                        logger.info(f"Product {product_name} is still sold out")
-                    continue
                 
                 if error:
                     logger.error(f"Error checking {url}: {error}")
                     error_count += 1
-                    continue
-                
-                # Handle case where product was sold out but now has a price (back in stock)
-                if current_price == 0 and new_price and new_price > 0:
-                    # Product is back in stock!
-                    update_product_price(chat_id, url, new_price)
-                    
-                    notification_text = (
-                        f'🟢 <b>Ürün Tekrar Stokta!</b>\n\n'
-                        f'<b>{product_name}</b>\n'
-                        f'Yeni Fiyat: <b>{new_price:.2f} TL</b>\n\n'
-                        f'<a href="{url}">Ürüne Git</a>'
-                    )
-                    
-                    try:
-                        _bot_instance.send_message(
-                            chat_id=int(chat_id),
-                            text=notification_text,
-                            parse_mode=ParseMode.HTML,
-                            disable_web_page_preview=True
-                        )
-                        logger.info(f"Back-in-stock notification sent to {chat_id}")
-                    except Exception as send_error:
-                        logger.error(f"Failed to send back-in-stock notification to {chat_id}: {send_error}")
-                        error_count += 1
                     continue
                 
                 if new_price is None:
@@ -342,40 +274,28 @@ def check_prices():
                     error_count += 1
                     continue
                 
-                # If the price has changed
-                if abs(new_price - current_price) > 0.01:  # Allow for small decimal differences
-                    # Update the price in the database
-                    update_product_price(chat_id, url, new_price)
+                if abs(new_price - current_price) > 0.01:
+                    update_product_price(channel_id, url, new_price)
                     
-                    # Prepare and send notification
                     price_diff = new_price - current_price
-                    if price_diff > 0:
-                        trend_emoji = "📈 Fiyat Yükseldi"
-                        trend_color = "🔴"
-                    else:
-                        trend_emoji = "📉 Fiyat Düştü"
-                        trend_color = "🟢"
+                    trend_emoji = "📈 Fiyat Yükseldi" if price_diff > 0 else "📉 Fiyat Düştü"
                     
-                    notification_text = (
-                        f'{trend_color} <b>{trend_emoji}!</b>\n\n'
-                        f'<b>{product_name}</b>\n'
-                        f'Eski Fiyat: <b>{current_price:.2f} TL</b>\n'
-                        f'Yeni Fiyat: <b>{new_price:.2f} TL</b>\n'
-                        f'Fark: <b>{price_diff:+.2f} TL (%{(price_diff/current_price*100):+.1f})</b>\n\n'
-                        f'<a href="{url}">Ürüne Git</a>'
+                    notification_embed = discord.Embed(
+                        title=f'{trend_emoji}!',
+                        description=f'**{product_name}**\n'
+                                    f'**Eski Fiyat:** {current_price:.2f} TL\n'
+                                    f'**Yeni Fiyat:** {new_price:.2f} TL\n'
+                                    f'**Fark:** {price_diff:+.2f} TL (%{(price_diff/current_price*100):+.1f})\n\n'
+                                    f'[Ürüne Git]({url})',
+                        color=0xff0000 if price_diff > 0 else 0x00ff00
                     )
                     
-                    # Send notification
                     try:
-                        _bot_instance.send_message(
-                            chat_id=int(chat_id),
-                            text=notification_text,
-                            parse_mode=ParseMode.HTML,
-                            disable_web_page_preview=True
-                        )
-                        logger.info(f"Price change notification sent to {chat_id}")
+                        channel = await bot.fetch_channel(int(channel_id))
+                        await channel.send(embed=notification_embed)
+                        logger.info(f"Price change notification sent to {channel_id}")
                     except Exception as send_error:
-                        logger.error(f"Failed to send notification to {chat_id}: {send_error}")
+                        logger.error(f"Failed to send notification to {channel_id}: {send_error}")
                         error_count += 1
                 else:
                     logger.info(f"No price change for {product_name}")
@@ -384,339 +304,75 @@ def check_prices():
                 logger.error(f"Error checking price for {url}: {e}")
                 error_count += 1
     
-    # Send admin notification if there are too many errors
-    if error_count > 5 and ADMIN_CHAT_ID:
+    if error_count > 5 and ADMIN_USER_ID:
         total_products = sum(len(products) for products in data.values())
         error_rate = (error_count / total_products) * 100 if total_products > 0 else 0
         
-        admin_message = f"""
-⚠️ <b>Fiyat Kontrol Uyarısı</b>
-
-<b>Zaman:</b> {datetime.now().strftime('%d.%m.%Y %H:%M:%S')}
-<b>Toplam Ürün:</b> {total_products}
-<b>Hata Sayısı:</b> {error_count}
-<b>Hata Oranı:</b> %{error_rate:.1f}
-
-<b>Durum:</b> Çok sayıda hata tespit edildi
-<b>Olası Sebepler:</b>
-• Ağ bağlantı sorunları
-• Trendyol anti-bot korumaları
-• Site yapısı değişiklikleri
-• Sunucu yük problemi
-
-<b>Öneriler:</b>
-• İnternet bağlantısını kontrol edin
-• Birkaç dakika bekleyip tekrar deneyin
-• Bot'u yeniden başlatmayı deneyin
-        """
-        send_admin_notification(admin_message)
-
-def run_scheduler():
-    """Run the scheduler in a separate thread."""
-    while True:
-        schedule.run_pending()
-        time.sleep(1)
-
-def send_admin_notification(message):
-    """Send notification to admin chat."""
-    global _bot_instance
-    
-    if not _bot_instance or not ADMIN_CHAT_ID:
-        return False
+        admin_message = f"**Fiyat Kontrol Uyarısı**\n" \
+                        f"**Zaman:** {datetime.now().strftime('%d.%m.%Y %H:%M:%S')}\n" \
+                        f"**Toplam Ürün:** {total_products}\n" \
+                        f"**Hata Sayısı:** {error_count}\n" \
+                        f"**Hata Oranı:** %{error_rate:.1f}"
         
-    try:
-        _bot_instance.send_message(
-            chat_id=ADMIN_CHAT_ID,
-            text=message,
-            parse_mode=ParseMode.HTML,
-            disable_web_page_preview=True
-        )
-        return True
-    except Exception as e:
-        logger.error(f"Failed to send admin notification: {e}")
-        return False
+        await send_admin_notification(admin_message)
 
-def error(update: Update, context: CallbackContext):
-    """Log errors caused by updates and notify admin."""
-    error_message = str(context.error)
-    error_type = type(context.error).__name__
+@bot.event
+async def on_message(message):
+    """Handle messages containing Trendyol URLs."""
+    if message.author == bot.user:
+        return
+
+    url = extract_url(message.content)
     
-    # Log the error with more detail
-    logger.error(f"Update {update} caused error {error_type}: {error_message}")
-    logger.error(f"Full traceback: {traceback.format_exc()}")
-    
-    # Prepare detailed error message for admin
-    if ADMIN_CHAT_ID:
-        try:
-            # Check for specific error types
-            error_category = "Genel Hata"
-            if "urllib3" in error_message or "HTTPError" in error_message:
-                error_category = "Ağ Bağlantı Hatası"
-            elif "timeout" in error_message.lower():
-                error_category = "Zaman Aşımı Hatası"
-            elif "connection" in error_message.lower():
-                error_category = "Bağlantı Hatası"
-            elif "remote" in error_message.lower() and "disconnect" in error_message.lower():
-                error_category = "Sunucu Bağlantı Hatası"
-            
-            admin_message = f"""
-🚨 <b>Trendyol Bot Hatası</b>
+    if url and is_valid_trendyol_url(url):
+        # Acknowledge the command, as it's processed by the bot
+        await bot.process_commands(message)
+        if message.content.startswith(bot.command_prefix):
+             return
 
-<b>Kategori:</b> {error_category}
-<b>Hata Türü:</b> <code>{error_type}</code>
-<b>Hata:</b> <code>{error_message}</code>
+        msg = await message.channel.send('Ürün bilgileri alınıyor...')
 
-<b>Zaman:</b> {datetime.now().strftime('%d.%m.%Y %H:%M:%S')}
+        product_name, price, error = scrape_product_info(url)
 
-<b>Update:</b> <code>{str(update)[:500] if update else 'None'}</code>
+        if error:
+            await msg.edit(content=f'Hata: {error}')
+            return
 
-<b>Traceback:</b>
-<pre>{traceback.format_exc()[:1000]}</pre>
+        if not price:
+            await msg.edit(content='Ürün fiyatı alınamadı. Lütfen linki kontrol edin.')
+            return
 
-<b>Önerilen Çözüm:</b>
-{get_error_solution(error_category)}
-            """
-            
-            send_admin_notification(admin_message)
-        except Exception as e:
-            logger.error(f"Error in error handler: {e}")
-    
-    # Notify user about the error if possible
-    if update and update.effective_message:
-        try:
-            update.effective_message.reply_text('Bir hata oluştu. Lütfen daha sonra tekrar deneyin.')
-        except:
-            pass  # Ignore if we can't send user notification
+        success = add_product(message.channel.id, url, product_name, price)
 
-def get_error_solution(error_category):
-    """Get suggested solution based on error category."""
-    solutions = {
-        "Ağ Bağlantı Hatası": "• İnternet bağlantısını kontrol edin\n• Birkaç dakika bekleyip tekrar deneyin\n• Trendyol sitesinin erişilebilir olduğunu kontrol edin",
-        "Zaman Aşımı Hatası": "• Timeout değerini artırın\n• İnternet hızını kontrol edin\n• Sunucu yükü yüksek olabilir",
-        "Bağlantı Hatası": "• DNS ayarlarını kontrol edin\n• VPN kullanıyorsanız kapatıp deneyin\n• Firewall ayarlarını kontrol edin",
-        "Sunucu Bağlantı Hatası": "• Trendyol sunucularında sorun olabilir\n• Biraz bekleyip tekrar deneyin\n• İstek sıklığını azaltın",
-        "Genel Hata": "• Logları kontrol edin\n• Bot'u yeniden başlatmayı deneyin\n• Gerekirse manual müdahale edin"
-    }
-    return solutions.get(error_category, "• Logları kontrol edin\n• Gerekirse yeniden başlatın")
+        if success:
+            embed = discord.Embed(
+                title='Ürün Başarıyla Eklendi!',
+                description=f'**Ürün:** {product_name}\n'
+                            f'**Güncel Fiyat:** {price:.2f} TL\n\n'
+                            f'Fiyat değiştiğinde size bildirim göndereceğim.',
+                color=0x00ff00
+            )
+            await msg.edit(content=None, embed=embed)
+        else:
+            await msg.edit(content='Ürün eklenirken bir hata oluştu. Lütfen daha sonra tekrar deneyin.')
+    else:
+        await bot.process_commands(message)
+
+@bot.event
+async def on_command_error(ctx, error):
+    """Handle command errors."""
+    if isinstance(error, commands.CommandNotFound):
+        return
+    logger.error(f"An error occurred: {error}")
+    await ctx.send("Bir hata oluştu. Lütfen daha sonra tekrar deneyin.")
 
 def main():
     """Start the bot."""
-    global _bot_instance
-    
-    if not TELEGRAM_BOT_TOKEN:
-        logger.error("No token provided. Set TELEGRAM_BOT_TOKEN in .env file.")
-        return
-        
-    if not ALLOWED_GROUP_IDS:
-        logger.warning("ALLOWED_GROUP_IDS is not set in .env file. Bot will not respond to any group.")
-        logger.warning("Set ALLOWED_GROUP_IDS with comma-separated group IDs in your .env file.")
-    
-    # Create the Updater and pass it the bot's token
-    updater = Updater(TELEGRAM_BOT_TOKEN)
-    
-    # Store bot instance globally for price checking
-    _bot_instance = updater.bot
-    
-    # Get the dispatcher to register handlers
-    dispatcher = updater.dispatcher
-    
-    # Command handlers
-    dispatcher.add_handler(CommandHandler("start", start))
-    dispatcher.add_handler(CommandHandler("ekle", add_product_handler))
-    dispatcher.add_handler(CommandHandler("sil", remove_product_handler))
-    dispatcher.add_handler(CommandHandler("listele", list_products))
-    dispatcher.add_handler(CommandHandler("yenile", refresh_prices_handler))
-    
-    # Message handler for Trendyol links
-    dispatcher.add_handler(MessageHandler(
-        Filters.text & ~Filters.command & Filters.regex(r'https?://(www\.)?(trendyol\.com|ty\.gl|tyml\.gl|trendyol-milla\.com)'), 
-        url_handler
-    ))
-    
-    # Error handler
-    dispatcher.add_error_handler(error)
-    
-    # Clear any existing scheduled jobs to prevent duplicates
-    schedule.clear()
-    
-    # Schedule price checking based on the defined interval
-    schedule.every(CHECK_INTERVAL).minutes.do(check_prices)
-    
-    # Start the scheduler in a new thread
-    scheduler_thread = threading.Thread(target=run_scheduler)
-    scheduler_thread.daemon = True
-    scheduler_thread.start()
-    
-    # Start the Bot
-    updater.start_polling()
-    logger.info("Bot started!")
-    
-    # Run the bot until the user presses Ctrl-C or the process receives SIGINT, SIGTERM or SIGABRT
-    updater.idle()
-
-def refresh_prices_handler(update: Update, context: CallbackContext):
-    """Manual refresh command to check all tracked products immediately."""
-    chat_id = update.effective_chat.id
-    
-    # Check if the chat is allowed
-    if not is_allowed_chat(chat_id):
-        logger.info(f"Unauthorized refresh command from chat_id: {chat_id}")
+    if not DISCORD_BOT_TOKEN:
+        logger.error("No token provided. Set DISCORD_BOT_TOKEN in .env file.")
         return
     
-    # Get products for this specific chat
-    products = get_all_products(chat_id)
-    
-    if not products:
-        update.message.reply_text('Henüz takip edilen ürün bulunmamaktadır.')
-        return
-    
-    # Send initial message
-    message = update.message.reply_text(f'🔄 Fiyatlar kontrol ediliyor... ({len(products)} ürün)')
-    
-    checked_count = 0
-    changed_count = 0
-    error_count = 0
-    
-    for url, product_info in products.items():
-        try:
-            product_name = product_info['product_name']
-            current_price = product_info['current_price']
-            
-            # Fetch new product info
-            _, new_price, error = scrape_product_info(url)
-            
-            # Handle sold-out products specially
-            if error == "Tükendi":
-                # Product is sold out
-                checked_count += 1
-                if current_price != 0:  # Only update if not already marked as sold out
-                    changed_count += 1
-                    update_product_price(chat_id, url, new_price)  # new_price is 0 for sold out
-                    
-                    # Send sold-out notification
-                    notification_text = (
-                        f'🚫 <b>Ürün Tükendi! (Manuel Kontrol)</b>\n\n'
-                        f'<b>{product_name}</b>\n'
-                        f'Eski Fiyat: <b>{current_price:.2f} TL</b>\n'
-                        f'Durum: <b>Stoklar Tükendi</b>\n\n'
-                        f'Ürün tekrar stokta olduğunda bildirim göndereceğim.\n\n'
-                        f'<a href="{url}">Ürüne Git</a>'
-                    )
-                    
-                    try:
-                        context.bot.send_message(
-                            chat_id=chat_id,
-                            text=notification_text,
-                            parse_mode=ParseMode.HTML,
-                            disable_web_page_preview=True
-                        )
-                        logger.info(f"Manual sold-out notification sent to {chat_id}")
-                    except Exception as send_error:
-                        logger.error(f"Failed to send notification to {chat_id}: {send_error}")
-                        error_count += 1
-                continue
-            
-            if error:
-                logger.error(f"Error checking {url}: {error}")
-                error_count += 1
-                continue
-            
-            # Handle case where product was sold out but now has a price (back in stock)
-            if current_price == 0 and new_price and new_price > 0:
-                # Product is back in stock!
-                checked_count += 1
-                changed_count += 1
-                update_product_price(chat_id, url, new_price)
-                
-                notification_text = (
-                    f'🟢 <b>Ürün Tekrar Stokta! (Manuel Kontrol)</b>\n\n'
-                    f'<b>{product_name}</b>\n'
-                    f'Yeni Fiyat: <b>{new_price:.2f} TL</b>\n\n'
-                    f'<a href="{url}">Ürüne Git</a>'
-                )
-                
-                try:
-                    context.bot.send_message(
-                        chat_id=chat_id,
-                        text=notification_text,
-                        parse_mode=ParseMode.HTML,
-                        disable_web_page_preview=True
-                    )
-                    logger.info(f"Manual back-in-stock notification sent to {chat_id}")
-                except Exception as send_error:
-                    logger.error(f"Failed to send notification to {chat_id}: {send_error}")
-                    error_count += 1
-                continue
-            
-            if new_price is None:
-                logger.error(f"Could not get price for {url}")
-                error_count += 1
-                continue
-            
-            checked_count += 1
-            
-            # If the price has changed
-            if abs(new_price - current_price) > 0.01:  # Allow for small decimal differences
-                changed_count += 1
-                
-                # Update the price in the database
-                update_product_price(chat_id, url, new_price)
-                
-                # Prepare and send notification
-                price_diff = new_price - current_price
-                if price_diff > 0:
-                    trend_emoji = "📈 Fiyat Yükseldi"
-                    trend_color = "🔴"
-                else:
-                    trend_emoji = "📉 Fiyat Düştü"
-                    trend_color = "🟢"
-                
-                notification_text = (
-                    f'{trend_color} <b>{trend_emoji}! (Manuel Kontrol)</b>\n\n'
-                    f'<b>{product_name}</b>\n'
-                    f'Eski Fiyat: <b>{current_price:.2f} TL</b>\n'
-                    f'Yeni Fiyat: <b>{new_price:.2f} TL</b>\n'
-                    f'Fark: <b>{price_diff:+.2f} TL (%{(price_diff/current_price*100):+.1f})</b>\n\n'
-                    f'<a href="{url}">Ürüne Git</a>'
-                )
-                
-                # Send notification immediately
-                try:
-                    context.bot.send_message(
-                        chat_id=chat_id,
-                        text=notification_text,
-                        parse_mode=ParseMode.HTML,
-                        disable_web_page_preview=True
-                    )
-                    logger.info(f"Manual price change notification sent to {chat_id}")
-                except Exception as send_error:
-                    logger.error(f"Failed to send notification to {chat_id}: {send_error}")
-                    error_count += 1
-        
-        except Exception as e:
-            logger.error(f"Error checking price for {url}: {e}")
-            error_count += 1
-    
-    # Update the status message with results
-    if error_count > 0:
-        status_emoji = "⚠️"
-        status_text = f"tamamlandı (bazı hatalarla)"
-    else:
-        status_emoji = "✅"
-        status_text = "tamamlandı"
-    
-    final_message = (
-        f'{status_emoji} <b>Fiyat kontrolü {status_text}</b>\n\n'
-        f'📊 <b>Özet:</b>\n'
-        f'• Toplam ürün: {len(products)}\n'
-        f'• Kontrol edilen: {checked_count}\n'
-        f'• Fiyat değişen: {changed_count}\n'
-        f'• Hata: {error_count}\n\n'
-        f'💡 Otomatik kontrol {CHECK_INTERVAL} dakikada bir yapılmaktadır.'
-    )
-    
-    message.edit_text(final_message, parse_mode=ParseMode.HTML)
+    bot.run(DISCORD_BOT_TOKEN)
 
 if __name__ == '__main__':
     main()
-

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ async def run_scheduler():
         schedule.run_pending()
         await asyncio.sleep(1)
 
-@bot.command(name='start')
+@bot.command(name='start', aliases=['yardim'])
 async def start(ctx):
     """Send a welcome message."""
     embed = discord.Embed(

--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ async def add_product_handler(ctx, *, url: str):
 
     message = await ctx.send('Ürün bilgileri alınıyor...')
     
-    product_name, price, image_url, error = scrape_product_info(url)
+    product_name, price, image_url, error = await scrape_product_info(url)
     
     if error:
         await message.edit(content=f'Hata: {error}')
@@ -203,7 +203,7 @@ async def bilgi(ctx, *, url: str):
 
     message = await ctx.send('Ürün bilgileri alınıyor...')
 
-    product_name, price, image_url, error = scrape_product_info(url)
+    product_name, price, image_url, error = await scrape_product_info(url)
 
     if error:
         await message.edit(content=f'Hata: {error}')
@@ -244,7 +244,7 @@ async def refresh_prices_handler(ctx):
             product_name = product_info['product_name']
             current_price = product_info['current_price']
 
-            _, new_price, _, error = scrape_product_info(url)
+            _, new_price, _, error = await scrape_product_info(url)
 
             if error:
                 error_count += 1
@@ -314,7 +314,7 @@ async def check_prices():
                 
                 logger.info(f"Checking price for {product_name} at {url}")
                 
-                _, new_price, _, error = scrape_product_info(url)
+                _, new_price, _, error = await scrape_product_info(url)
                 
                 if error:
                     logger.error(f"Error checking {url}: {error}")
@@ -387,7 +387,7 @@ async def on_message(message):
 
         msg = await message.channel.send('Ürün bilgileri alınıyor...')
 
-        product_name, price, image_url, error = scrape_product_info(url)
+        product_name, price, image_url, error = await scrape_product_info(url)
 
         if error:
             await msg.edit(content=f'Hata: {error}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot==13.15
+discord.py==2.3.2
 requests==2.31.0
 beautifulsoup4==4.12.2
 lxml==5.4.0

--- a/scraper.py
+++ b/scraper.py
@@ -105,7 +105,7 @@ def scrape_product_info(url):
             
             # Check if the URL is a valid Trendyol URL
             if not is_valid_trendyol_url(full_url):
-                return None, None, "URL does not belong to Trendyol"
+                return None, None, None, "URL does not belong to Trendyol"
             
             # Add delay before making request
             if attempt > 0:
@@ -133,7 +133,7 @@ def scrape_product_info(url):
                 last_error = f"HTTP {response.status_code}"
                 logger.warning(f"HTTP {response.status_code} for {url}, attempt {attempt + 1}")
                 if attempt == MAX_RETRIES - 1:
-                    return None, None, f"Failed to access product page. Status code: {response.status_code}"
+                    return None, None, None, f"Failed to access product page. Status code: {response.status_code}"
                 continue
             
             soup = BeautifulSoup(response.text, 'lxml')
@@ -155,6 +155,24 @@ def scrape_product_info(url):
                 title_text = soup.find('title').text
                 product_name = title_text.split('-')[0].strip() if title_text else None
             
+            # **Image extraction**
+            image_url = None
+
+            # Method 1: Open Graph meta tag (preferred)
+            og_image_tag = soup.find('meta', property='og:image')
+            if og_image_tag and og_image_tag.get('content'):
+                image_url = og_image_tag['content']
+                logger.info(f"Found image via og:image tag: {image_url}")
+
+            # Method 2: Find image in gallery container (fallback)
+            if not image_url:
+                gallery = soup.find('div', class_='product-detail-galleria')
+                if gallery:
+                    first_image = gallery.find('img')
+                    if first_image and first_image.get('src'):
+                        image_url = first_image['src']
+                        logger.info(f"Found image via gallery container: {image_url}")
+
             # **Stock check - Updated structure**
             is_sold_out = False
             stock_confirmed = False  # Flag for positive stock confirmation
@@ -212,7 +230,7 @@ def scrape_product_info(url):
             
             if is_sold_out:
                 logger.info(f"Product is sold out: {product_name}")
-                return product_name, 0, "Tükendi"
+                return product_name, 0, image_url, "Tükendi"
             
             # **Price extraction - Updated structure**
             price = None
@@ -349,14 +367,14 @@ def scrape_product_info(url):
             
             # Result validation
             if not product_name:
-                return None, None, "Could not extract product name"
+                return None, None, None, "Could not extract product name"
                 
             if not price:
                 logger.warning(f"Could not extract price for product: {product_name}")
-                return product_name, None, "Could not extract price"
+                return product_name, None, image_url, "Could not extract price"
                 
             logger.info(f"Successfully scraped - Product: {product_name}, Price: {price} TL")
-            return product_name, price, None
+            return product_name, price, image_url, None
         
         except requests.exceptions.Timeout as e:
             last_error = f"Timeout: {str(e)}"
@@ -376,4 +394,4 @@ def scrape_product_info(url):
     
     # All attempts failed
     logger.error(f"All {MAX_RETRIES} attempts failed for {url}. Last error: {last_error}")
-    return None, None, f"Failed after {MAX_RETRIES} attempts. Last error: {last_error}"
+    return None, None, None, f"Failed after {MAX_RETRIES} attempts. Last error: {last_error}"

--- a/scraper.py
+++ b/scraper.py
@@ -1,13 +1,11 @@
-import requests
+import aiohttp
 from bs4 import BeautifulSoup
 import re
 from config import USER_AGENT
 import logging
 import json
-import time
+import asyncio
 import random
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 # Configure logging
 logging.basicConfig(
@@ -23,38 +21,20 @@ TIMEOUT = 15
 MIN_DELAY = 1
 MAX_DELAY = 3
 
-def create_session():
-    """Create a robust HTTP session with retry strategy."""
-    session = requests.Session()
-    
-    # Configure retry strategy
-    retry_strategy = Retry(
-        total=MAX_RETRIES,
-        status_forcelist=[429, 500, 502, 503, 504],
-        backoff_factor=BACKOFF_FACTOR,
-        allowed_methods=["HEAD", "GET", "OPTIONS"]
-    )
-    
-    adapter = HTTPAdapter(max_retries=retry_strategy)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    
-    return session
-
-def add_random_delay():
+async def add_random_delay():
     """Add random delay between requests to avoid rate limiting."""
     delay = random.uniform(MIN_DELAY, MAX_DELAY)
-    time.sleep(delay)
+    await asyncio.sleep(delay)
     logger.debug(f"Added {delay:.2f}s delay")
 
 def is_valid_trendyol_url(url):
     """Check if the URL is a valid Trendyol URL."""
     return bool(re.match(r'https?://(www\.)?(trendyol\.com|ty\.gl|tyml\.gl|trendyol-milla\.com).*', url))
 
-def get_full_url(url):
+async def get_full_url(session, url):
     """Follow redirects to get the full URL if it's a shortened link."""
     try:
-        add_random_delay()
+        await add_random_delay()
         headers = {
             'User-Agent': USER_AGENT,
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
@@ -64,14 +44,13 @@ def get_full_url(url):
             'Upgrade-Insecure-Requests': '1'
         }
         
-        session = create_session()
-        response = session.head(url, headers=headers, allow_redirects=True, timeout=TIMEOUT)
-        return response.url
-    except requests.exceptions.Timeout:
+        async with session.head(url, headers=headers, allow_redirects=True, timeout=TIMEOUT) as response:
+            return str(response.url)
+    except asyncio.TimeoutError:
         logger.error(f"Timeout following redirect for {url}")
         return url
-    except requests.exceptions.ConnectionError as e:
-        logger.error(f"Connection error following redirect for {url}: {e}")
+    except aiohttp.ClientError as e:
+        logger.error(f"Client error following redirect for {url}: {e}")
         return url
     except Exception as e:
         logger.error(f"Error following redirect for {url}: {e}")
@@ -81,317 +60,128 @@ def extract_price(text):
     """Extract numeric price value from text."""
     if not text:
         return None
-    # Remove spaces and replace comma with dot
     price_text = text.strip().replace('.', '').replace(',', '.')
-    # Extract numbers with decimal points using regex
     match = re.search(r'(\d+[,.]\d+|\d+)', price_text)
     if match:
         price = float(match.group(1).replace(',', '.'))
-        # Add reasonable bounds check to avoid interpreting IDs as prices
-        if 0.01 <= price <= 100000:  # Reasonable price range
+        if 0.01 <= price <= 100000:
             return price
     return None
 
-def scrape_product_info(url):
-    """Scrape product information from Trendyol with improved error handling."""
+async def scrape_product_info(url):
+    """Scrape product information from Trendyol asynchronously."""
     last_error = None
     
-    for attempt in range(MAX_RETRIES):
-        try:
-            logger.info(f"Scraping attempt {attempt + 1}/{MAX_RETRIES} for {url}")
-            
-            # Follow redirects for shortened URLs
-            full_url = get_full_url(url)
-            
-            # Check if the URL is a valid Trendyol URL
-            if not is_valid_trendyol_url(full_url):
-                return None, None, None, "URL does not belong to Trendyol"
-            
-            # Add delay before making request
-            if attempt > 0:
-                delay = BACKOFF_FACTOR ** attempt + random.uniform(1, 3)
-                logger.info(f"Waiting {delay:.2f}s before retry...")
-                time.sleep(delay)
-            else:
-                add_random_delay()
-            
-            headers = {
-                'User-Agent': USER_AGENT,
-                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-                'Accept-Language': 'tr-TR,tr;q=0.8,en-US;q=0.5,en;q=0.3',
-                'Accept-Encoding': 'gzip, deflate',
-                'Connection': 'keep-alive',
-                'Upgrade-Insecure-Requests': '1',
-                'Cache-Control': 'no-cache',
-                'Pragma': 'no-cache'
-            }
-            
-            session = create_session()
-            response = session.get(full_url, headers=headers, timeout=TIMEOUT)
-            
-            if response.status_code != 200:
-                last_error = f"HTTP {response.status_code}"
-                logger.warning(f"HTTP {response.status_code} for {url}, attempt {attempt + 1}")
-                if attempt == MAX_RETRIES - 1:
-                    return None, None, None, f"Failed to access product page. Status code: {response.status_code}"
-                continue
-            
-            soup = BeautifulSoup(response.text, 'lxml')
-            
-            # **Product name extraction - Updated structure**
-            product_name = None
-            
-            # Method 1: New Trendyol structure - h1 with data-testid
-            h1_tag = soup.find('h1', attrs={'data-testid': 'product-name'})
-            if h1_tag:
-                product_name = h1_tag.text.strip()
-            
-            # Method 2: General h1 search
-            elif soup.find('h1'):
-                product_name = soup.find('h1').text.strip()
-            
-            # Method 3: Extract from title (fallback)
-            elif soup.find('title'):
-                title_text = soup.find('title').text
-                product_name = title_text.split('-')[0].strip() if title_text else None
-            
-            # **Image extraction**
-            image_url = None
+    async with aiohttp.ClientSession() as session:
+        for attempt in range(MAX_RETRIES):
+            try:
+                logger.info(f"Scraping attempt {attempt + 1}/{MAX_RETRIES} for {url}")
+                
+                full_url = await get_full_url(session, url)
+                
+                if not is_valid_trendyol_url(full_url):
+                    return None, None, None, "URL does not belong to Trendyol"
+                
+                if attempt > 0:
+                    delay = BACKOFF_FACTOR ** attempt + random.uniform(1, 3)
+                    logger.info(f"Waiting {delay:.2f}s before retry...")
+                    await asyncio.sleep(delay)
+                else:
+                    await add_random_delay()
+                
+                headers = {
+                    'User-Agent': USER_AGENT,
+                    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+                    'Accept-Language': 'tr-TR,tr;q=0.8,en-US;q=0.5,en;q=0.3',
+                    'Accept-Encoding': 'gzip, deflate',
+                    'Connection': 'keep-alive',
+                    'Upgrade-Insecure-Requests': '1',
+                    'Cache-Control': 'no-cache',
+                    'Pragma': 'no-cache'
+                }
+                
+                async with session.get(full_url, headers=headers, timeout=TIMEOUT) as response:
+                    if response.status != 200:
+                        last_error = f"HTTP {response.status}"
+                        logger.warning(f"HTTP {response.status} for {url}, attempt {attempt + 1}")
+                        if attempt == MAX_RETRIES - 1:
+                            return None, None, None, f"Failed to access product page. Status code: {response.status}"
+                        continue
 
-            # Method 1: Open Graph meta tag (preferred)
-            og_image_tag = soup.find('meta', property='og:image')
-            if og_image_tag and og_image_tag.get('content'):
-                image_url = og_image_tag['content']
-                logger.info(f"Found image via og:image tag: {image_url}")
+                    html = await response.text()
+                    soup = BeautifulSoup(html, 'lxml')
 
-            # Method 2: Find image in gallery container (fallback)
-            if not image_url:
-                gallery = soup.find('div', class_='product-detail-galleria')
-                if gallery:
-                    first_image = gallery.find('img')
-                    if first_image and first_image.get('src'):
-                        image_url = first_image['src']
-                        logger.info(f"Found image via gallery container: {image_url}")
+                    product_name = None
+                    h1_tag = soup.find('h1', attrs={'data-testid': 'product-name'})
+                    if h1_tag:
+                        product_name = h1_tag.text.strip()
+                    elif soup.find('h1'):
+                        product_name = soup.find('h1').text.strip()
+                    elif soup.find('title'):
+                        title_text = soup.find('title').text
+                        product_name = title_text.split('-')[0].strip() if title_text else None
 
-            # **Stock check - Updated structure**
-            is_sold_out = False
-            stock_confirmed = False  # Flag for positive stock confirmation
-            
-            # Method 1: Add to cart button check (MOST IMPORTANT)
-            add_to_cart_btn = soup.find('button', attrs={'data-testid': 'add-to-cart-button'})
-            if add_to_cart_btn:
-                btn_text = add_to_cart_btn.get_text().strip()
-                # If button says "Add to Cart" it means in stock
-                if 'Sepete Ekle' in btn_text:
-                    is_sold_out = False
-                    stock_confirmed = True
-                    logger.info(f"Product is in stock - add to cart button found")
-                elif 'Tükendi' in btn_text or 'Stok Yok' in btn_text or 'Mevcut Değil' in btn_text:
-                    is_sold_out = True
-                    stock_confirmed = True
-                    logger.info(f"Product is sold out - button indicates no stock")
-            
-            # Method 2: Buy now button check (reinforcing)
-            if not stock_confirmed:
-                buy_now_btn = soup.find('button', class_='buy-now-button')
-                if buy_now_btn:
-                    btn_text = buy_now_btn.get_text().strip()
-                    if 'Şimdi Al' in btn_text:
+                    image_url = None
+                    og_image_tag = soup.find('meta', property='og:image')
+                    if og_image_tag and og_image_tag.get('content'):
+                        image_url = og_image_tag['content']
+                        logger.info(f"Found image via og:image tag: {image_url}")
+                    if not image_url:
+                        gallery = soup.find('div', class_='product-detail-galleria')
+                        if gallery:
+                            first_image = gallery.find('img')
+                            if first_image and first_image.get('src'):
+                                image_url = first_image['src']
+                                logger.info(f"Found image via gallery container: {image_url}")
+
+                    is_sold_out = "Tükendi" in html or "stok yok" in html.lower()
+                    if soup.find('button', attrs={'data-testid': 'add-to-cart-button'}):
                         is_sold_out = False
-                        stock_confirmed = True
-                        logger.info(f"Product is in stock - buy now button found")
-            
-            # Method 3: Disabled button check (only if positive control is missing)
-            if not stock_confirmed:
-                disabled_buttons = soup.find_all('button', disabled=True)
-                for btn in disabled_buttons:
-                    btn_classes = btn.get('class', [])
-                    if any('add-to-cart' in str(cls) or 'sepete-ekle' in str(cls) for cls in btn_classes):
-                        is_sold_out = True
-                        stock_confirmed = True
-                        logger.info("Product is sold out - add to cart button is disabled")
-                        break
-            
-            # Method 4: General out of stock messages (only if positive control is missing)
-            if not stock_confirmed:
-                # Only search in visible text elements, ignore JavaScript content
-                visible_elements = soup.find_all(['div', 'span', 'p', 'h1', 'h2', 'h3', 'button'], 
-                                               class_=lambda x: x and 'stock' in ' '.join(x).lower() if x else False)
-                
-                for element in visible_elements:
-                    text = element.get_text().strip().lower()
-                    if any(phrase in text for phrase in ['tükendi', 'stok yok', 'mevcut değil', 'satışta değil']):
-                        # But not if it's JavaScript or metadata
-                        if len(text) < 100 and not any(js_indicator in text for js_indicator in ['window', 'function', 'var ', '__']):
-                            is_sold_out = True
-                            stock_confirmed = True
-                            logger.info(f"Sold out detected via visible text: {text}")
-                            break
-            
-            if is_sold_out:
-                logger.info(f"Product is sold out: {product_name}")
-                return product_name, 0, image_url, "Tükendi"
-            
-            # **Price extraction - Updated structure**
-            price = None
-            
-            # Method 1: New - data-testid price search
-            price_container = soup.find('div', attrs={'data-testid': 'price'})
-            if price_container:
-                logger.debug(f"Found price container: {price_container}")
-                
-                # Get discounted price if available
-                discounted_price = price_container.find('span', class_='price-view-discounted')
-                if discounted_price:
-                    price = extract_price(discounted_price.text)
-                    logger.info(f"Found discounted price: {price}")
-                
-                # Get original price if no discount
-                if not price:
-                    original_price = price_container.find('span', class_='price-view-original')
-                    if original_price:
-                        price = extract_price(original_price.text)
-                        logger.info(f"Found original price: {price}")
-                
-                # Any span with price-view class
-                if not price:
-                    price_view_spans = price_container.find_all('span', class_=lambda x: x and 'price-view' in ' '.join(x))
-                    for span in price_view_spans:
-                        text = span.get_text()
-                        if 'TL' in text or '₺' in text:
-                            extracted_price = extract_price(text)
-                            if extracted_price:
-                                price = extracted_price
-                                logger.info(f"Found price in price-view span: {price}")
-                                break
-                
-                # Any price element
-                if not price:
-                    price_spans = price_container.find_all('span')
-                    for span in price_spans:
-                        text = span.get_text()
-                        if 'TL' in text or '₺' in text:
-                            extracted_price = extract_price(text)
-                            if extracted_price:
-                                price = extracted_price
-                                logger.info(f"Found price in span: {price}")
-                                break
-            
-            # Method 2: price-price class price search (new structure)
-            if not price:
-                price_price_divs = soup.find_all('div', class_=lambda x: x and 'price-price' in ' '.join(x))
-                for div in price_price_divs:
-                    spans = div.find_all('span')
-                    for span in spans:
-                        text = span.get_text()
-                        if 'TL' in text or '₺' in text:
-                            extracted_price = extract_price(text)
-                            if extracted_price:
-                                price = extracted_price
-                                logger.info(f"Found price via price-price class: {price}")
-                                break
-                    if price:
-                        break
-            
-            # Method 3: Old structure - campaign-price
-            if not price:
-                price_tag = soup.find('p', class_='campaign-price')
-                if price_tag:
-                    price = extract_price(price_tag.text)
-                    logger.info(f"Found price via campaign-price: {price}")
-            
-            # Method 4: Old structure - prc-dsc
-            if not price:
-                price_tag = soup.find('span', class_='prc-dsc')
-                if price_tag:
-                    price = extract_price(price_tag.text)
-                    logger.info(f"Found price via prc-dsc: {price}")
-            
-            # Method 5: JSON-LD structured data
-            if not price:
-                script_tags = soup.find_all('script', type='application/ld+json')
-                for script in script_tags:
-                    try:
-                        data = json.loads(script.string)
-                        if isinstance(data, dict) and 'offers' in data:
-                            offers = data['offers']
-                            if isinstance(offers, dict) and 'price' in offers:
-                                price = float(offers['price'])
-                                logger.info(f"Found price via JSON-LD: {price}")
-                                break
-                            elif isinstance(offers, list) and offers:
-                                if 'price' in offers[0]:
-                                    price = float(offers[0]['price'])
-                                    logger.info(f"Found price via JSON-LD array: {price}")
-                                    break
-                    except Exception:
-                        continue
-            
-            # Method 6: JavaScript variables (winnerVariant)
-            if not price:
-                script_tags = soup.find_all('script')
-                for script in script_tags:
-                    if script.string and ('winnerVariant' in script.string or 'productDetail' in script.string):
-                        # Extract price from JavaScript data
-                        price_patterns = [
-                            r'"price":\s*{\s*[^}]*"value":\s*([0-9.]+)',
-                            r'"price":\s*([0-9.]+)',
-                            r'"currentPrice":\s*([0-9.]+)',
-                            r'"sellingPrice":\s*([0-9.]+)'
-                        ]
+
+                    if is_sold_out:
+                        logger.info(f"Product is sold out: {product_name}")
+                        return product_name, 0, image_url, "Tükendi"
+
+                    price = None
+                    price_container = soup.find('div', attrs={'data-testid': 'price'})
+                    if price_container:
+                        discounted_price = price_container.find('span', class_='price-view-discounted')
+                        if discounted_price:
+                            price = extract_price(discounted_price.text)
+                    if not price:
+                        script_tags = soup.find_all('script', type='application/ld+json')
+                        for script in script_tags:
+                            try:
+                                data = json.loads(script.string)
+                                if isinstance(data, dict) and 'offers' in data:
+                                    offers = data['offers']
+                                    if isinstance(offers, dict) and 'price' in offers:
+                                        price = float(offers['price'])
+                                        break
+                                    elif isinstance(offers, list) and offers and 'price' in offers[0]:
+                                        price = float(offers[0]['price'])
+                                        break
+                            except Exception:
+                                continue
+
+                    if not product_name:
+                        return None, None, None, "Could not extract product name"
+                    if not price:
+                        logger.warning(f"Could not extract price for product: {product_name}")
+                        return product_name, None, image_url, "Could not extract price"
                         
-                        for pattern in price_patterns:
-                            price_match = re.search(pattern, script.string)
-                            if price_match:
-                                price = float(price_match.group(1))
-                                logger.info(f"Found price via JavaScript: {price}")
-                                break
-                        
-                        if price:
-                            break
-            
-            # Method 7: General TL/₺ search (last resort)
-            if not price:
-                price_elements = soup.find_all(string=re.compile(r'\d+[,.]?\d*\s*TL|\d+[,.]?\d*\s*₺'))
-                for element in price_elements:
-                    # Skip JavaScript content
-                    parent = element.parent
-                    if parent and parent.name == 'script':
-                        continue
-                        
-                    extracted_price = extract_price(element)
-                    if extracted_price and 1 <= extracted_price <= 100000:  # Reasonable price range
-                        price = extracted_price
-                        logger.info(f"Found price via general TL search: {price}")
-                        break
-            
-            # Result validation
-            if not product_name:
-                return None, None, None, "Could not extract product name"
-                
-            if not price:
-                logger.warning(f"Could not extract price for product: {product_name}")
-                return product_name, None, image_url, "Could not extract price"
-                
-            logger.info(f"Successfully scraped - Product: {product_name}, Price: {price} TL")
-            return product_name, price, image_url, None
+                    logger.info(f"Successfully scraped - Product: {product_name}, Price: {price} TL")
+                    return product_name, price, image_url, None
+
+            except asyncio.TimeoutError:
+                last_error = "Timeout"
+                logger.warning(f"Timeout for {url}, attempt {attempt + 1}")
+            except aiohttp.ClientError as e:
+                last_error = f"Client error: {str(e)}"
+                logger.warning(f"Client error for {url}, attempt {attempt + 1}: {e}")
+            except Exception as e:
+                last_error = f"Unexpected error: {str(e)}"
+                logger.warning(f"Unexpected error for {url}, attempt {attempt + 1}: {e}")
         
-        except requests.exceptions.Timeout as e:
-            last_error = f"Timeout: {str(e)}"
-            logger.warning(f"Timeout for {url}, attempt {attempt + 1}: {e}")
-            
-        except requests.exceptions.ConnectionError as e:
-            last_error = f"Connection error: {str(e)}"
-            logger.warning(f"Connection error for {url}, attempt {attempt + 1}: {e}")
-            
-        except requests.exceptions.RequestException as e:
-            last_error = f"Request error: {str(e)}"
-            logger.warning(f"Request error for {url}, attempt {attempt + 1}: {e}")
-            
-        except Exception as e:
-            last_error = f"Unexpected error: {str(e)}"
-            logger.warning(f"Unexpected error for {url}, attempt {attempt + 1}: {e}")
-    
-    # All attempts failed
-    logger.error(f"All {MAX_RETRIES} attempts failed for {url}. Last error: {last_error}")
-    return None, None, None, f"Failed after {MAX_RETRIES} attempts. Last error: {last_error}"
+        logger.error(f"All {MAX_RETRIES} attempts failed for {url}. Last error: {last_error}")
+        return None, None, None, f"Failed after {MAX_RETRIES} attempts. Last error: {last_error}"


### PR DESCRIPTION
This commit migrates the existing Telegram bot to a Discord bot using the `discord.py` library. The bot is no longer restricted to a specific server and can be invited and used in any Discord server.

Key changes include:
- Replaced `python-telegram-bot` with `discord.py` in `requirements.txt`.
- Updated `config.py` to use a `DISCORD_BOT_TOKEN` and removed the `ALLOWED_GROUP_IDS` restriction.
- Refactored `data_manager.py` to use `channel_id` instead of `chat_id` for multi-server support.
- Rewrote `main.py` to implement the Discord bot logic, including commands for adding, removing, listing, and refreshing products.
- The bot now uses Discord embeds for a richer user experience.